### PR TITLE
Allow more recent versions of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pydantic==2.7.0
-requests==2.31.0
-typing_extensions==4.11.0
-pytest==8.2.0
-requests-mock==1.12.0
+pydantic=>2.7.0
+requests>=2.31.0
+typing_extensions>=4.11.0
+pytest>=8.2.0
+requests-mock>=1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic=>2.7.0
+pydantic>=2.7.0
 requests>=2.31.0
 typing_extensions>=4.11.0
 pytest>=8.2.0


### PR DESCRIPTION
In general, Python libraries should not depend on fixed versions of their dependencies. Update requirements.txt to set a minimum version of the packages we depend on but no upper limit. This will allow pysgconnect to be installed as a dependency of applications that use more recent versions of these packages.